### PR TITLE
Install mdbook-mermaid to deployment workflow

### DIFF
--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -29,7 +29,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      MDBOOK_VERSION: 0.4.21
+      MDBOOK_VERSION: 0.4.34
     steps:
       - uses: actions/checkout@v3
       - name: Install mdBook

--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -37,6 +37,7 @@ jobs:
           curl --proto '=https' --tlsv1.2 https://sh.rustup.rs -sSf -y | sh
           rustup update
           cargo install --version ${MDBOOK_VERSION} mdbook
+          cargo install mdbook-mermaid
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@v3

--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -7,7 +7,7 @@ name: Deploy mdBook site to Pages
 on:
   # Runs on pushes targeting the default branch
   push:
-    branches: ["master"]
+    branches: ["add_mdbook_mermaid_preprocessor_to_deployment_workflow"]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -7,7 +7,7 @@ name: Deploy mdBook site to Pages
 on:
   # Runs on pushes targeting the default branch
   push:
-    branches: ["add_mdbook_mermaid_preprocessor_to_deployment_workflow"]
+    branches: ["master"]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
This pr fixes the issue from the deployed book: https://calendar-team.github.io/calendar-docs/architecture.html
![image](https://github.com/calendar-team/calendar-docs/assets/18382999/e3442772-6c86-4cac-9d9f-f917c3bb8c1e)

We need the mdbook-mermaid preprocessor to be available when the book is deployed on Github Pages